### PR TITLE
[Enhancement] Introduce Tabbed UX

### DIFF
--- a/classes/class-wp-live-debug-server-info.php
+++ b/classes/class-wp-live-debug-server-info.php
@@ -38,27 +38,25 @@ if ( ! class_exists( 'WP_Live_Debug_Server_Info' ) ) {
 		public static function create_page() {
 			?>
 				<div class="sui-box">
-					<div class="sui-box-header">
-						<h2 class="sui-box-title"><?php esc_html_e( 'Server', 'wp-live-debug' ); ?></h2>
-					</div>
-					<div class="sui-box-body" id="server-info">
-						<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
-					</div>
-				</div>
-				<div class="sui-box">
-					<div class="sui-box-header">
-						<h2 class="sui-box-title"><?php esc_html_e( 'MySQL', 'wp-live-debug' ); ?></h2>
-					</div>
-					<div class="sui-box-body" id="mysql-info">
-						<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
-					</div>
-				</div>
-				<div class="sui-box">
-					<div class="sui-box-header">
-						<h2 class="sui-box-title"><?php esc_html_e( 'PHP', 'wp-live-debug' ); ?></h2>
-					</div>
-					<div class="sui-box-body" id="php-info">
-						<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
+					<div class="sui-box-body">
+						<div class="sui-tabs">
+							<div data-tabs>
+								<div><?php esc_html_e( 'Server', 'wp-live-debug' ); ?></div>
+								<div><?php esc_html_e( 'MySQL', 'wp-live-debug' ); ?></div>
+								<div><?php esc_html_e( 'PHP', 'wp-live-debug' ); ?></div>
+							</div>
+							<div data-panes>
+								<div id="server-info">
+									<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
+								</div>
+								<div id="mysql-info">
+									<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
+								</div>
+								<div id="php-info">
+									<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
+								</div>
+							</div>
+						</div>
 					</div>
 				</div>
 			<?php

--- a/classes/class-wp-live-debug-tools.php
+++ b/classes/class-wp-live-debug-tools.php
@@ -56,42 +56,41 @@ if ( ! class_exists( 'WP_Live_Debug_Tools' ) ) {
 			);
 			?>
 				<div class="sui-box">
-					<div class="sui-box-header">
-						<h2 class="sui-box-title"><?php esc_html_e( 'SSL Information', 'wp-live-debug' ); ?></h2>
-					</div>
-					<div class="sui-box-body" id="ssl-response">
-					</div>
-				</div>
-				<div class="sui-box">
-					<div class="sui-box-header">
-						<h2 class="sui-box-title"><?php esc_html_e( 'Checksums Check', 'wp-live-debug' ); ?></h2>
-					</div>
-					<div class="sui-box-body" id="checksums-response">
-						<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
-					</div>
-				</div>
-				<div class="sui-box" id="mail-check-box">
-					<div class="sui-box-header">
-						<h2 class="sui-box-title"><?php esc_html_e( 'wp_mail() Check', 'wp-live-debug' ); ?></h2>
-					</div>
 					<div class="sui-box-body">
-						<form action="#" id="wp-live-debug-mail-check" method="POST">
-							<div class="sui-form-field">
-								<label for="email" class="sui-label"><?php esc_html_e( 'E-mail', 'wp-live-debug' ); ?></label>
-								<input type="email" id="email" name="email" class="sui-form-control" value="<?php echo $current_user->user_email; ?>">
+						<div class="sui-tabs">
+							<div data-tabs>
+								<div><?php esc_html_e( 'SSL Information', 'wp-live-debug' ); ?></div>
+								<div><?php esc_html_e( 'Checksums Check', 'wp-live-debug' ); ?></div>
+								<div><?php esc_html_e( 'wp_mail() Check', 'wp-live-debug' ); ?></div>
 							</div>
-							<div class="sui-form-field">
-								<label for="email_subject" class="sui-label"><?php esc_html_e( 'Subject', 'wp-live-debug' ); ?></label>
-								<input type="text" id="email_subject" name="email_subject" class="sui-form-control" value="<?php echo $email_subject; ?>">
+							<div data-panes>
+								<div id="ssl-response"></div>
+								<div id="checksums-response">
+									<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
+								</div>
+								<div id="mail-check-box">
+									<div class="sui-box-body">
+										<form action="#" id="wp-live-debug-mail-check" method="POST">
+											<div class="sui-form-field">
+												<label for="email" class="sui-label"><?php esc_html_e( 'E-mail', 'wp-live-debug' ); ?></label>
+												<input type="email" id="email" name="email" class="sui-form-control" value="<?php echo $current_user->user_email; ?>">
+											</div>
+											<div class="sui-form-field">
+												<label for="email_subject" class="sui-label"><?php esc_html_e( 'Subject', 'wp-live-debug' ); ?></label>
+												<input type="text" id="email_subject" name="email_subject" class="sui-form-control" value="<?php echo $email_subject; ?>">
+											</div>
+											<div class="sui-form-field">
+												<label for="email_message" class="sui-label"><?php esc_html_e( 'Message', 'wp-live-debug' ); ?></label>
+												<textarea id="email_message" name="email_message" class="sui-form-control" rows="4"><?php echo $email_body; ?></textarea>
+											</div>
+											<div class="sui-form-field">
+												<input type="submit" class="sui-button sui-button-green" value="<?php esc_html_e( 'Send test mail', 'wp-live-debug' ); ?>">
+											</div>
+										</form>
+									</div>
+								</div>
 							</div>
-							<div class="sui-form-field">
-								<label for="email_message" class="sui-label"><?php esc_html_e( 'Message', 'wp-live-debug' ); ?></label>
-								<textarea id="email_message" name="email_message" class="sui-form-control" rows="4"><?php echo $email_body; ?></textarea>
-							</div>
-							<div class="sui-form-field">
-								<input type="submit" class="sui-button sui-button-green" value="<?php esc_html_e( 'Send test mail', 'wp-live-debug' ); ?>">
-							</div>
-						</form>
+						</div>
 					</div>
 				</div>
 				<div class="sui-dialog sui-dialog-lg" aria-hidden="true" tabindex="-1" id="checksums-popup">

--- a/classes/class-wp-live-debug-wordpress-info.php
+++ b/classes/class-wp-live-debug-wordpress-info.php
@@ -38,38 +38,32 @@ if ( ! class_exists( 'WP_Live_Debug_WordPress_Info' ) ) {
 
 		public static function create_page() {
 			?>
-			<div class="sui-box">
-				<div class="sui-box-header">
-					<h2 class="sui-box-title">General Information</h2>
+				<div class="sui-box">
+					<div class="sui-box-body">
+						<div class="sui-tabs">
+							<div data-tabs>
+								<div><?php esc_html_e( 'General Information', 'wp-live-debug' ); ?></div>
+								<div><?php esc_html_e( 'Directory Permissions', 'wp-live-debug' ); ?></div>
+								<div><?php esc_html_e( 'Installation Size', 'wp-live-debug' ); ?></div>
+								<div><?php esc_html_e( 'Constants', 'wp-live-debug' ); ?></div>
+							</div>
+							<div data-panes>
+								<div id="gen-info">
+									<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
+								</div>
+								<div id="dir-perm">
+									<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
+								</div>
+								<div id="dir-size">
+									<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
+								</div>
+								<div id="constants-info">
+									<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
+								</div>
+							</div>
+						</div>
+					</div>
 				</div>
-				<div class="sui-box-body" id="gen-info">
-					<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
-				</div>
-			</div>
-			<div class="sui-box">
-				<div class="sui-box-header">
-					<h2 class="sui-box-title"><?php esc_html_e( 'Directory Permissions', 'wp-live-debug' ); ?></h2>
-				</div>
-				<div class="sui-box-body" id="dir-perm">
-					<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
-				</div>
-			</div>
-			<div class="sui-box">
-				<div class="sui-box-header">
-					<h2 class="sui-box-title"><?php esc_html_e( 'Installation Size', 'wp-live-debug' ); ?></h2>
-				</div>
-				<div class="sui-box-body" id="dir-size">
-					<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
-				</div>
-			</div>
-			<div class="sui-box">
-				<div class="sui-box-header">
-					<h2 class="sui-box-title"><?php esc_html_e( 'Constants', 'wp-live-debug' ); ?></h2>
-				</div>
-				<div class="sui-box-body" id="constants-info">
-					<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>
-				</div>
-			</div>
 			<?php
 		}
 


### PR DESCRIPTION
## Description
This PR introduces a tabbed UX for the plugin pages that have multiple info sections to show ("WordPress", "Server", and "Tools" as of now). The purpose is to ensure a better UX and reduce scroll lengths.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Installed and activated the plugin.
2. Went to Dashboard->WP Live Debug.
3. Made sure info sections inside "WordPress", "Server" and "Tools" pages show up in their respective tabs and they work well.

This was tested with WordPress 4.9.8, WP Live Debug 4.9.8 and this change doesn't seem to affect anything else.

## Screenshots <!-- if applicable -->
![1](https://user-images.githubusercontent.com/20284937/44997286-f5659880-afce-11e8-93d6-42f1087cf8da.png)

## Types of changes
This PR just adds the tab element from the Shared UI and wraps up the page sections in their own respective tabs.
