### PR TITLE
Checks user permission before actually processing emails.

### DIFF
--- a/classes/class-wp-live-debug-tools.php
+++ b/classes/class-wp-live-debug-tools.php
@@ -390,6 +390,12 @@ if ( ! class_exists( 'WP_Live_Debug_Tools' ) ) {
 		 * @return void
 		 */
 		public static function send_mail() {
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_send_json_error(array(
+					'message' => __( 'Does your mom know you\'re doing this?', 'wp-live-debug' ),
+				));
+			}
+
 			$output        = '';
 			$sendmail      = false;
 			$email         = sanitize_email( $_POST['email'] );


### PR DESCRIPTION
Without permissions check, the AJAX action will send out emails no
questions asked, just by virtue of the AJAX call being issued by a site
user - regardless of their access level.