### PR TITLE
[Enhancement] Introduce SSL Check trigger on Return Key Press

### DIFF
--- a/classes/class-wp-live-debug-tools.php
+++ b/classes/class-wp-live-debug-tools.php
@@ -73,11 +73,13 @@ if ( ! class_exists( 'WP_Live_Debug_Tools' ) ) {
 							</div>
 							<div data-panes>
 								<div id="ssl-holder" class="active">
-								<div class="sui-with-button">
-									<input id="ssl-host" type="text" id="demo-input-button-large" class="sui-form-control" value="<?php echo $host; ?>">
-									<button id="check-ssl" class="sui-button sui-button-lg sui-button-green"><?php esc_html_e( 'Verify', 'wp-live-debug' ); ?></button>
-								</div>
-								<div id="ssl-response"></div>
+									<form>
+										<div class="sui-with-button">
+												<input id="ssl-host" type="text" id="demo-input-button-large" class="sui-form-control" value="<?php echo $host; ?>">
+												<button id="check-ssl" type="submit" class="sui-button sui-button-lg sui-button-green"><?php esc_html_e( 'Verify', 'wp-live-debug' ); ?></button>
+										</div>
+									</form>
+									<div id="ssl-response"></div>
 								</div>
 								<div id="checksums-response">
 									<i class="sui-icon-loader sui-loading" aria-hidden="true"></i>


### PR DESCRIPTION
## Description
This PR closes #11 where I filed an enhancement, to make the SSL Check trigger on "Return" key press in the input field.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Installed and activated the plugin.
2. Went to Dashboard->WP Live Debug->Tools->SSL Information.
3. Entered a site address in the SSL host field and made sure it triggered the SSL check on "Return" key press.

This was tested with WordPress 4.9.8, WP Live Debug 4.9.8.2 and this change doesn't seem to affect anything else.

## Screenshots <!-- if applicable -->
![pull-11](https://user-images.githubusercontent.com/20284937/45017032-4bc2ed80-b048-11e8-86e6-06463ea914cc.gif)

## Types of changes
This PR wraps up the `input` and `button` elements inside a `form` and assigns a `submit` `type` attribute to the `button`.
