### PR TITLE
[Fix] Remove Additional Unnecessary ID

### DIFF
--- a/classes/class-wp-live-debug-tools.php
+++ b/classes/class-wp-live-debug-tools.php
@@ -74,7 +74,7 @@ if ( ! class_exists( 'WP_Live_Debug_Tools' ) ) {
 							<div data-panes>
 								<div id="ssl-holder" class="active">
 								<div class="sui-with-button">
-									<input id="ssl-host" type="text" id="demo-input-button-large" class="sui-form-control" value="<?php echo $host; ?>">
+									<input id="ssl-host" type="text" class="sui-form-control" value="<?php echo $host; ?>">
 									<button id="check-ssl" class="sui-button sui-button-lg sui-button-green"><?php esc_html_e( 'Verify', 'wp-live-debug' ); ?></button>
 								</div>
 								<div id="ssl-response"></div>


### PR DESCRIPTION
## Description
This PR closes #13 where I reported usage of a stale `id` attribute in the "Tools" file, within the SSL Check.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Installed and activated the plugin.
2. Went to Dashboard->WP Live Debug->Tools->SSL Information.
3. Made sure the SSL check functions correctly even with the mentioned attribute removed.

This was tested with WordPress 4.9.8, WP Live Debug 4.9.8.2 and this change doesn't seem to affect anything else.

## Types of changes
This PR removes the additional `id` attribute with the value `demo-input-button-large` from the `input#ssl-host` element in _classes/class-wp-live-debug-tools.php_.